### PR TITLE
fix: change license headers from javadoc to regular comment style

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: cui parent pom
 pages-reference: cui-parent-pom
 release:
-  current-version: 1.1.0
+  current-version: 1.1.1
   next-version: 1.1.1-SNAPSHOT

--- a/cui-java-bom/cui-java-parent/pom.xml
+++ b/cui-java-bom/cui-java-parent/pom.xml
@@ -236,7 +236,7 @@
                                 <email>info@cuioss.de</email>
                             </properties>
                             <mapping>
-                                <java>JAVADOC_STYLE</java>
+                                <java>SLASHSTAR_STYLE</java>
                             </mapping>
                             <licenseSets>
                                 <licenseSet>
@@ -376,6 +376,56 @@
                         <configuration>
                             <argLine>${argLine}</argLine>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!-- TODO: Remove this profile in version 1.2.0 -->
+            <!-- Temporary profile to clean up existing javadoc-style license headers -->
+            <!-- Usage: ./mvnw -Plicense-cleanup -->
+            <id>license-cleanup</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.mycila</groupId>
+                        <artifactId>license-maven-plugin</artifactId>
+                        <version>${license-maven-plugin.version}</version>
+                        <configuration>
+                            <properties>
+                                <year>2025</year>
+                                <owner>CUI-OpenSource-Software</owner>
+                                <email>info@cuioss.de</email>
+                            </properties>
+                            <mapping>
+                                <java>SLASHSTAR_STYLE</java>
+                            </mapping>
+                            <licenseSets>
+                                <licenseSet>
+                                    <header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
+                                    <includes>
+                                        <include>src/main/java/**</include>
+                                        <include>src/test/java/**</include>
+                                    </includes>
+                                </licenseSet>
+                            </licenseSets>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>remove-old-headers</id>
+                                <phase>process-sources</phase>
+                                <goals>
+                                    <goal>remove</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>format-new-headers</id>
+                                <phase>process-sources</phase>
+                                <goals>
+                                    <goal>format</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
## Summary
- Change license plugin mapping from JAVADOC_STYLE to SLASHSTAR_STYLE
- Add temporary license-cleanup profile for migration (remove in v1.2.0)
- Resolves javadoc formatting issues and IDE warnings about "dangling javadoc comments"

## Changes
- **License Plugin Configuration**: Updated `cui-java-bom/cui-java-parent/pom.xml:239` to use `SLASHSTAR_STYLE` instead of `JAVADOC_STYLE`
- **Temporary Migration Profile**: Added `license-cleanup` profile for safe migration from `/** */` to `/* */` headers
- **Version Update**: Updated release version to 1.1.1

## Benefits
- ✅ License headers use proper `/* */` format instead of `/** */`
- ✅ Eliminates IDE warnings about dangling javadoc comments
- ✅ Prevents license text from appearing in generated javadoc documentation
- ✅ Follows Java best practices for license headers
- ✅ Works seamlessly with POM-only packaging

## Migration Process
1. **Descendant projects**: Run `mvn -Plicense-cleanup` once to migrate existing headers
2. **Future updates**: Use `mvn -Ppre-commit` as normal (now uses SLASHSTAR_STYLE)
3. **Profile removal**: The temporary `license-cleanup` profile will be removed in v1.2.0

## Test plan
- [ ] Test license header generation with new SLASHSTAR_STYLE
- [ ] Verify existing headers are properly replaced using license-cleanup profile
- [ ] Confirm no javadoc pollution in generated documentation
- [ ] Test with descendant projects like cui-java-tools

Fixes #909

🤖 Generated with [Claude Code](https://claude.ai/code)