### PR TITLE
fix: wire javadoc plugin failOnError and legacyMode properties into configuration

### DIFF
--- a/cui-java-bom/cui-java-parent/pom.xml
+++ b/cui-java-bom/cui-java-parent/pom.xml
@@ -45,6 +45,8 @@
                         <doctitle>${project.name}</doctitle>
                         <!--https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#BEJEFABE -->
                         <doclint>${maven.javadoc.plugin.doclint}</doclint>
+                        <failOnError>${maven.javadoc.plugin.failOnError}</failOnError>
+                        <legacyMode>${maven.javadoc.plugin.legacyMode}</legacyMode>
                     </configuration>
                     <executions>
                         <execution>
@@ -341,6 +343,8 @@
                             <splitindex>true</splitindex>
                             <doctitle>${project.name}</doctitle>
                             <doclint>${maven.javadoc.plugin.doclint}</doclint>
+                            <failOnError>${maven.javadoc.plugin.failOnError}</failOnError>
+                            <legacyMode>${maven.javadoc.plugin.legacyMode}</legacyMode>
                         </configuration>
                         <executions>
                             <execution>


### PR DESCRIPTION
## Summary
- Wire `failOnError` and `legacyMode` properties into both the `pluginManagement` and `pre-commit` profile javadoc plugin `<configuration>` blocks
- These properties were defined but never referenced in configuration, so child projects could not override them
- Follows the existing pattern used by `doclint`

Closes #1088

## Test plan
- [x] `./mvnw verify` passes (all 7 modules BUILD SUCCESS)
- [ ] Verify effective POM shows `failOnError` and `legacyMode` in javadoc plugin configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)