### PR TITLE
build(deps): bump maven-enforcer-plugin from 3.5.0 to 3.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
         <maven.dependency.plugin.version>3.9.0</maven.dependency.plugin.version>
         <maven.deploy.plugin.version>3.1.4</maven.deploy.plugin.version>
-        <maven.enforcer.plugin.version>3.5.0</maven.enforcer.plugin.version>
+        <maven.enforcer.plugin.version>3.6.2</maven.enforcer.plugin.version>
         <maven.failsafe.plugin.version>3.5.4</maven.failsafe.plugin.version>
         <maven.gpg.plugin.version>3.2.8</maven.gpg.plugin.version>
         <maven.install.plugin.version>3.1.4</maven.install.plugin.version>
@@ -251,7 +251,9 @@
                                     </requirePropertyDiverges>
                                     <requireSameVersions>
                                         <plugins>
-                                            <plugin>org.apache.maven.plugins</plugin>
+                                            <plugin>org.apache.maven.plugins:maven-surefire-plugin</plugin>
+                                            <plugin>org.apache.maven.plugins:maven-failsafe-plugin</plugin>
+                                            <plugin>org.apache.maven.plugins:maven-surefire-report-plugin</plugin>
                                         </plugins>
                                     </requireSameVersions>
                                 </rules>


### PR DESCRIPTION
## Summary

- Bumps `maven-enforcer-plugin` from 3.5.0 to 3.6.2
- Fixes `requireSameVersions` rule configuration that broke with the upgrade

## Root Cause

Enforcer 3.6.0 included a bug fix ([PR #892](https://github.com/apache/maven-enforcer/pull/892), [Issue #372](https://github.com/apache/maven-enforcer/issues/372)) that made the `<plugins>` parameter in `requireSameVersions` actually work — in 3.5.0 it was silently ignored.

The old configuration used a groupId-only wildcard (`org.apache.maven.plugins`) which matched **all** Apache plugins and required them to share one version. This is impossible since different plugins have different release cycles (compiler 3.15.0, site 3.21.0, surefire 3.5.4, etc.).

The rule is now narrowed to enforce version alignment only for the surefire/failsafe family, which is the actual intent:
- `maven-surefire-plugin`
- `maven-failsafe-plugin`
- `maven-surefire-report-plugin`

This resolves the issue that caused PRs #901, #906, #913, and #970 to fail.

Closes #970

## Test plan

- [x] `./mvnw verify` passes across all 7 modules
- [x] All 6 enforcer rules pass including `RequireSameVersions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)