### PR TITLE
docs: project review & fix plan (doc/review-26-07-04.md)

### DIFF
--- a/doc/review-26-07-04.md
+++ b/doc/review-26-07-04.md
@@ -1,0 +1,411 @@
+# Project Review & Fix Plan — 2026-07-04
+
+Full review of `cui-parent-pom` (`de.cuioss:cui-parent-pom:1.4-SNAPSHOT`).
+
+> **Scope of this document:** This is a **plan / review / hints for fixing only**.
+> No production configuration is changed by this document. Each finding lists the
+> file, the problem, a fix hint, and how to verify. The findings are grouped into
+> **four sensible, independent pull-request clusters** (A–D) that can be executed
+> one after another (or in parallel where noted).
+
+## Methodology
+
+The whole repository (45 files) was reviewed manually:
+
+* All 7 `pom.xml` files (root + `cui-java-bom`, `cui-java-parent`, `java-ee-bom`,
+  `java-ee-10-bom`, `quarkus-bom`, `java-ee-orthogonal`).
+* All 6 GitHub Actions workflows + `dependabot.yml` + `project.yml`.
+* All AsciiDoc documentation (`README.adoc` × 5, `doc/*.adoc`) and `CLAUDE.md`.
+* Build tooling (`.mvn/wrapper`, `.editorconfig`, `.gitignore`, `src/site/site.xml`).
+
+**Build status:** `./mvnw -B --no-transfer-progress validate` and `verify`
+succeed cleanly. All enforcer rules pass. **No Maven warnings or deprecations
+were emitted.** Consequently every finding below is a **configuration or
+documentation defect**, not a compilation/test failure. There is no Java source
+in this repository — it is a POM-and-BOM aggregator.
+
+## Severity legend
+
+| Level | Meaning |
+|-------|---------|
+| 🔴 High | Functional defect — a feature does not work as intended. |
+| 🟠 Medium | Inconsistency / dead config / stale docs that misleads maintainers or violates a stated invariant. |
+| 🟡 Low | Cosmetic, typo, or minor hygiene. |
+
+---
+
+## Findings overview
+
+| # | Sev | Area | Finding | Cluster |
+|---|-----|------|---------|---------|
+| 1 | 🔴 | Dependabot | `dependabot.yml` has invalid YAML indentation — `cooldown` block is nested under `open-pull-requests-limit`. | A |
+| 2 | 🟠 | CI | `claude.yml` uses unpinned actions (`@beta`, `@v6.0.3`), violating the repo's own "all actions pinned by SHA" invariant. | A |
+| 3 | 🟡 | Dependabot | `github-actions` update block has no `open-pull-requests-limit`; `time: "04:00"` has no timezone. | A |
+| 4 | 🟡 | CI | `maven.yml` push branch filter does not include the `claude/**` branch namespace. | A |
+| 5 | 🟠 | POM | Obsolete `license-cleanup` profile — its own comment says "Remove in version 1.2.0"; project is at 1.4. | C |
+| 6 | 🟠 | POM | Dead property `given.parent.version` (root `pom.xml`) — defined, never referenced. | B |
+| 7 | 🟠 | POM | Dead property `version.jakarta.jakartaee-web-api` (=10.0.0) — defined, never referenced; the web-api dependency actually uses `version.jakarta.ee.web-api` (=11.0.0). | B |
+| 8 | 🟠 | POM | Inconsistent `xsi:schemaLocation` — 3 variants incl. a wrong host (`www.apache.org`) and plain `http`. | B |
+| 9 | 🟡 | POM | Typo in `quarkus-bom` description: "plufins" → "plugins". | B |
+| 10 | 🟠 | POM | Hardcoded license header year `<year>2025</year>` (× 2) in `cui-java-parent`. | C |
+| 11 | 🟠 | Docs/POM | `build-plantuml` profile + `doc/Build.adoc` PlantUML section + `doc/images/*.png` are orphaned — no `doc/plantuml/` dir and no `.puml` sources exist. | D |
+| 12 | 🟡 | Docs | `doc/Build.adoc` wrapper-update instructions reference the obsolete takari plugin; the wrapper is Maven's own `only-script` 3.3.2. | D |
+| 13 | 🟡 | Docs | `doc/signing_key.adoc` uses Markdown ATX headers (`#`, `##`) inside an AsciiDoc file. | D |
+| 14 | 🟡 | Docs | `CLAUDE.md` + `cui-java-parent/README.adoc` still document the to-be-removed `license-cleanup` profile / "1.2.0" note. | C |
+| 15 | 🟡 | Docs | `README.adoc` sample pins a stale `1.4.1` parent version (current release 1.4.5). | D |
+
+Optional / observational (no action strictly required — see notes): architectural
+naming of `java-ee-10-bom` (bundles some Jakarta EE **11** APIs), and the GPG
+signing key expiry `2026-12-03` noted in `doc/signing_key.adoc`.
+
+---
+
+## Detailed findings & fix hints
+
+### Finding 1 — 🔴 `dependabot.yml` invalid YAML indentation
+**File:** `.github/dependabot.yml` (lines 8–13)
+
+```yaml
+  open-pull-requests-limit: 10
+    cooldown:               # <-- indented UNDER the scalar "10"
+      default-days: 3
+      ...
+```
+
+The `cooldown` mapping is indented as if it were a child of the scalar
+`open-pull-requests-limit: 10`, which is not valid YAML. A standard parser
+(`python -c "import yaml; yaml.safe_load(...)"`) rejects the file. Introduced in
+PR #1240 (2026-05-21). Even though Dependabot has kept opening PRs, the
+`cooldown` settings are — at best — silently ignored, so the intended
+patch/minor/major cool-down windows are **not being applied**.
+
+**Fix hint:** De-indent `cooldown` to the same level as `open-pull-requests-limit`
+(2 spaces under the list item). Apply the same correction to the `github-actions`
+block (its `cooldown` is at the correct level already, but re-verify).
+
+```yaml
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "04:00"
+    timezone: "Europe/Berlin"        # see Finding 3
+  open-pull-requests-limit: 10
+  cooldown:
+    default-days: 3
+    semver-major-days: 7
+    semver-minor-days: 3
+    semver-patch-days: 1
+```
+
+**Verify:** `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"`
+exits 0; GitHub → Insights → Dependency graph → Dependabot shows no config error.
+
+---
+
+### Finding 2 — 🟠 Unpinned GitHub Actions in `claude.yml`
+**File:** `.github/workflows/claude.yml` (lines 29, 35)
+
+```yaml
+uses: actions/checkout@v6.0.3
+uses: anthropics/claude-code-action@beta
+```
+
+`doc/Build.adoc` explicitly asserts: *"All GitHub Actions in `.github/workflows/`
+are pinned by commit hash."* All other workflows honour this
+(`...@0af17b42…`). `claude.yml` breaks it — `@beta` is a moving tag (a
+reproducibility **and** supply-chain risk that OpenSSF Scorecard flags via the
+`scorecards.yml` job).
+
+**Fix hint:** Pin both to a full 40-char commit SHA with a trailing `# vX.Y.Z`
+comment, matching the house style, e.g.
+`uses: actions/checkout@<sha> # v6.0.3` and
+`uses: anthropics/claude-code-action@<sha> # <release>`. If tracking `@beta`
+intentionally, instead **amend the Build.adoc invariant** to document the
+exception — but pinning is preferred.
+
+**Verify:** `grep -rn "uses:" .github/workflows/ | grep -v '@[0-9a-f]\{40\}'`
+returns nothing.
+
+---
+
+### Finding 3 — 🟡 `dependabot.yml` minor gaps
+**File:** `.github/dependabot.yml`
+
+* The `github-actions` update block has no `open-pull-requests-limit` (defaults to
+  5; the maven block sets 10 — make the intent explicit).
+* `time: "04:00"` has no `timezone`, so it is interpreted as UTC. Set an explicit
+  `timezone` if a local window is desired.
+
+**Fix hint:** Add `open-pull-requests-limit` to the actions block and an explicit
+`timezone:` to both `schedule:` sections. (Fold into the Finding 1 edit.)
+
+---
+
+### Finding 4 — 🟡 `maven.yml` branch filter omits `claude/**`
+**File:** `.github/workflows/maven.yml` (line 7)
+
+```yaml
+branches: [main, "feature/*", "fix/*", "chore/*", "release/*", "dependabot/**"]
+```
+
+Pushes to `claude/**` branches (used by the Claude-on-web workflow, e.g. this very
+branch) do not trigger the build on push. PRs to `main` still build via the
+`pull_request` trigger, so impact is low, but adding the namespace gives push-time
+feedback.
+
+**Fix hint:** Add `"claude/**"` to the push `branches` list. Low priority /
+optional — decide whether push-time CI on assistant branches is wanted.
+
+---
+
+### Finding 5 — 🟠 Obsolete `license-cleanup` profile
+**File:** `cui-java-bom/cui-java-parent/pom.xml` (lines 416–465)
+
+The profile carries `<!-- TODO: Remove this profile in version 1.2.0 -->`. The
+project is now `1.4-SNAPSHOT` (released 1.4.5), so removal is overdue. It was a
+one-shot migration helper (javadoc-style → slashstar license headers) that has
+already been applied across consumers.
+
+**Fix hint:** Delete the whole `license-cleanup` profile. Coordinate with
+Finding 14 (remove its documentation in the same PR). Consider bumping the
+"remove in" bookkeeping so a stale TODO does not reappear.
+
+**Verify:** `./mvnw help:all-profiles` no longer lists `license-cleanup`; build
+still green.
+
+---
+
+### Finding 6 — 🟠 Dead property `given.parent.version`
+**File:** `pom.xml` (line 104)
+
+```xml
+<given.parent.version>${project.version}</given.parent.version>
+```
+
+The only occurrence in the whole tree is its own definition. It is never
+consumed.
+
+**Fix hint:** Remove the line. If it is retained for downstream/tooling reasons,
+add a comment explaining who reads it; otherwise delete.
+
+**Verify:** `grep -rn "given.parent.version" --include=*.xml .` returns only the
+(now removed) line / nothing.
+
+---
+
+### Finding 7 — 🟠 Dead property `version.jakarta.jakartaee-web-api`
+**File:** `java-ee-bom/java-ee-10-bom/pom.xml` (line 16, vs. lines 24 & 125)
+
+`version.jakarta.jakartaee-web-api` (=`10.0.0`) is defined but never referenced.
+The actual `jakarta.jakartaee-web-api` dependency (line 122–127) uses a
+*different* property `version.jakarta.ee.web-api` (=`11.0.0`). Two near-identically
+named properties for the same artifact, one dead, is a trap.
+
+**Fix hint:** Remove the unused `version.jakarta.jakartaee-web-api` property. While
+here, decide the intended web-api level (see the architectural note below) — the
+module is named `java-ee-10-bom` but pulls the Jakarta EE **11** web-api
+(`11.0.0`) and Servlet **6.1** (EE 11). If EE 10 is intended, downgrade; if EE 11
+is intended, the naming/docs should say so. **Do not change the resolved version
+silently** — raise it in the PR description for a maintainer decision.
+
+**Verify:** `grep -rn "jakartaee-web-api" --include=*.xml .` shows no dangling
+property; `./mvnw validate` green.
+
+---
+
+### Finding 8 — 🟠 Inconsistent `xsi:schemaLocation`
+**Files:** all 7 POMs (root uses wrong host; `cui-java-bom` uses plain `http`)
+
+Three variants exist:
+
+| Count | schemaLocation host | Where |
+|-------|---------------------|-------|
+| 1 | `http://www.apache.org/xsd/maven-4.0.0.xsd` (wrong host) | root `pom.xml` |
+| 1 | `http://maven.apache.org/xsd/maven-4.0.0.xsd` (http) | `cui-java-bom/pom.xml` |
+| 5 | `https://maven.apache.org/xsd/maven-4.0.0.xsd` | the rest |
+
+**Fix hint:** Standardize all seven to
+`https://maven.apache.org/xsd/maven-4.0.0.xsd` (and the matching namespace URI on
+the same line). Purely a header-line change; no build effect, but removes a
+correctness wart (`www.apache.org` does not host that XSD).
+
+**Verify:** `grep -rn "schemaLocation" --include=*.xml . | grep -o "http[s]*://[^ ]*maven-4.0.0.xsd" | sort -u` yields one line.
+
+---
+
+### Finding 9 — 🟡 Typo "plufins" in `quarkus-bom`
+**File:** `java-ee-bom/java-ee-10-bom/quarkus-bom/pom.xml` (line 11)
+
+```xml
+<description>Bundles all quarkus related dependencies / plufins</description>
+```
+
+**Fix hint:** "plufins" → "plugins".
+
+---
+
+### Finding 10 — 🟠 Hardcoded license year `2025`
+**File:** `cui-java-bom/cui-java-parent/pom.xml` (lines 236 and 429)
+
+Both the `pre-commit` and `license-cleanup` profiles hardcode
+`<year>2025</year>` in the `license-maven-plugin` config. Running `pre-commit` in
+2026+ stamps a stale year into new headers.
+
+**Fix hint:** Prefer a range or a dynamic value. Options: (a) use the plugin's
+default (drop the `<year>` override so it derives from the current year), or
+(b) set `<year>2022-${maven.build.timestamp}` style range via a build-helper
+timestamp property. Line 429 is inside the `license-cleanup` profile — if
+Finding 5 removes that profile, only line 236 remains. Sequence C accordingly.
+
+**Verify:** run `./mvnw -Ppre-commit` on a sample module; new headers show the
+current year.
+
+---
+
+### Finding 11 — 🟠 Orphaned PlantUML machinery
+**Files:** `pom.xml` `build-plantuml` profile (lines 677–720); `doc/Build.adoc`
+(PlantUML section, lines 59–98); `doc/images/*.png`.
+
+The `build-plantuml` profile scans `${project.basedir}/doc/plantuml/**/*.puml`,
+`Build.adoc` documents diagrams "stored in `/doc/plantuml/`", and CLAUDE.md lists
+`./mvnw generate-resources -Pbuild-plantuml`. **But `doc/plantuml/` does not
+exist and there are zero `.puml` files.** The six PNGs in `doc/images/`
+(`Parent.png`, `Sheriff.png`, `Detective.png`, `CUI-Base.png`,
+`Quality-Control.png`, `Craftsman.png`) are referenced by nothing. This is dead
+tooling + stale docs + orphaned binary assets.
+
+**Fix hint:** Two coherent options — pick one in the PR:
+* **Remove** the `build-plantuml` profile, its `plantuml-maven-plugin` dep, the
+  PlantUML section of `Build.adoc`, the CLAUDE.md command line, and the unused
+  `doc/images/*.png`; **or**
+* **Restore** the `doc/plantuml/*.puml` sources if the diagrams are meant to
+  exist and wire them into the docs.
+
+Given the PNGs are unreferenced, removal is the lower-risk default. **Flag for
+maintainer confirmation** in the PR before deleting binary assets.
+
+**Verify:** After removal — `grep -rn "plantuml" .` returns only intended hits;
+`./mvnw help:all-profiles` no longer lists `build-plantuml`.
+
+---
+
+### Finding 12 — 🟡 Stale wrapper-update instructions
+**File:** `doc/Build.adoc` (lines 10–19)
+
+The doc says run `./mvnw wrapper:wrapper` and references
+"takari-maven-wrapper-plugin". The actual wrapper is Maven's own
+(`wrapperVersion=3.3.2`, `distributionType=only-script`, Maven `3.9.6`).
+
+**Fix hint:** Update the instructions to the current
+`org.apache.maven.plugins:maven-wrapper-plugin` invocation (e.g.
+`./mvnw wrapper:wrapper -Dmaven=3.9.6`) and drop the takari reference.
+
+---
+
+### Finding 13 — 🟡 Markdown headers in AsciiDoc file
+**File:** `doc/signing_key.adoc`
+
+Uses `#`, `##` ATX headers (Markdown) instead of AsciiDoc `=`, `==`. Rendered as
+an AsciiDoc document (as the `.adoc` extension implies, and as the Maven site
+build treats it), the section structure is lost.
+
+**Fix hint:** Convert `#`→`=`, `##`→`==`, `###`→`===`. Optionally normalise the
+mixed German/English ("verfällt") while there.
+
+---
+
+### Finding 14 — 🟡 Docs still describe `license-cleanup`
+**Files:** `CLAUDE.md` ("Recent Changes" / "will be removed in version 1.2.0");
+`cui-java-bom/cui-java-parent/README.adoc` (`=== license-cleanup` section,
+lines 70–76).
+
+Ships in the **same PR as Finding 5** so code and docs stay in sync.
+
+**Fix hint:** Remove the `license-cleanup` profile subsection from the README and
+the corresponding note from CLAUDE.md.
+
+---
+
+### Finding 15 — 🟡 Stale sample version in `README.adoc`
+**File:** `README.adoc` (line 68)
+
+The "Usage for Standard java-modules" snippet pins `<version>1.4.1</version>` for
+`cui-java-parent`. Current release is 1.4.5.
+
+**Fix hint:** Either bump to the current release or switch the snippet to a
+`${version}` placeholder like the other usage examples in the same file, so it
+does not drift again.
+
+---
+
+## Observational notes (no mandatory change)
+
+* **`java-ee-10-bom` vs. Jakarta EE 11:** the module name says "ee-10" but it
+  manages Jakarta EE 11 artifacts (web-api `11.0.0`, servlet `6.1.0`). This may be
+  intentional forward-adoption. Recommend a one-line comment in the POM and a note
+  in the module README clarifying the target platform. Tracked as part of the
+  Finding 7 discussion; **do not re-version dependencies without maintainer
+  sign-off.**
+* **GPG signing key expiry:** `doc/signing_key.adoc` records the key as expiring
+  `2026-12-03`. Not a code issue, but worth a calendar reminder to rotate before
+  release deployments break.
+
+---
+
+## Proposed PR clusters (execution roadmap)
+
+The fixing work (a **separate** effort — not this document) should be split into
+four small, independently-reviewable PRs. Ordering minimises rebase churn; A and D
+are independent and may run in parallel.
+
+### PR-A — CI/CD & Dependabot hygiene  🔴 (do first)
+* Fix 1 (invalid `dependabot.yml` YAML) — **the only functional defect**.
+* Fix 2 (pin `claude.yml` actions by SHA).
+* Fix 3 (dependabot `open-pull-requests-limit` + `timezone`).
+* Fix 4 (optional: add `claude/**` to `maven.yml`).
+* **Risk:** low. **Verify:** YAML parses; `grep` for unpinned actions empty.
+
+### PR-B — POM cleanup (dead config, schema, typo)  🟠
+* Fix 6 (`given.parent.version`), Fix 7 (dead `jakartaee-web-api` property),
+  Fix 8 (schemaLocation), Fix 9 (typo).
+* Raise the EE-10-vs-EE-11 web-api question (Finding 7 / obs. note) for maintainer
+  decision — **no silent version change**.
+* **Risk:** low (headers/props only). **Verify:** `./mvnw validate` green;
+  grep checks clean.
+
+### PR-C — Retire `license-cleanup` + fix license year  🟠
+* Fix 5 (remove profile), Fix 14 (remove its docs in CLAUDE.md + README),
+  Fix 10 (license year 2025 → dynamic/range; note line 429 disappears with the
+  profile).
+* **Risk:** low. **Verify:** `help:all-profiles` clean; `-Ppre-commit` stamps
+  current year.
+
+### PR-D — Documentation accuracy  🟡 (independent)
+* Fix 11 (orphaned PlantUML profile + docs + images — **confirm deletion of PNGs
+  with maintainer**), Fix 12 (wrapper docs), Fix 13 (AsciiDoc headers),
+  Fix 15 (README sample version).
+* **Risk:** low, docs-only except the `build-plantuml` profile removal.
+  **Verify:** `grep` for `plantuml`/takari clean; site builds.
+
+### Suggested sequence
+
+```
+PR-A  ──►  PR-B  ──►  PR-C
+PR-D  (parallel, anytime)
+```
+
+Each PR: branch from `main`, single focused commit set, run
+`./mvnw -B --no-transfer-progress verify`, open PR, address bot review, merge.
+
+## Appendix — commands used for verification
+
+```bash
+./mvnw -B --no-transfer-progress validate          # build + enforcer, no warnings
+python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"   # FAILS today
+grep -rn "given.parent.version" --include=*.xml .  # dead property
+grep -rn "jakartaee-web-api"    --include=*.xml .   # dead property
+grep -rn "schemaLocation" --include=*.xml . | grep -o "http[s]*://[^ ]*maven-4.0.0.xsd" | sort -u
+grep -rn "uses:" .github/workflows/ | grep -v '@[0-9a-f]\{40\}'   # unpinned actions
+find . -name '*.puml' -not -path './.git/*'        # empty -> orphaned plantuml
+```


### PR DESCRIPTION
## Summary

Adds `doc/review-26-07-04.md` — a full review of `cui-parent-pom` with a concrete, partitioned fix plan.

**This PR is planning only.** It adds one documentation file. No POM, workflow, or behaviour changes are made here. The actual fixes are deliberately deferred to the follow-up PR clusters described in the document.

## What was analyzed

The whole repository (45 files) was reviewed manually: all 7 POMs, all 6 GitHub Actions workflows + `dependabot.yml` + `project.yml`, all AsciiDoc docs + `CLAUDE.md`, and build tooling. `./mvnw verify` was run — it succeeds with **no Maven warnings**, so every finding is a configuration/documentation defect (there is no Java source in this repo).

## Key findings (15 total)

| Sev | Finding |
|-----|---------|
| 🔴 High | `.github/dependabot.yml` is **invalid YAML** — the `cooldown` block is mis-indented under `open-pull-requests-limit`, so the cool-down windows are not applied. |
| 🟠 Med | `claude.yml` uses unpinned actions (`@beta`, `@v6.0.3`), violating the repo's own "all actions pinned by SHA" invariant. |
| 🟠 Med | Obsolete `license-cleanup` profile (TODO said remove in 1.2.0; now 1.4). |
| 🟠 Med | Dead POM properties (`given.parent.version`, `version.jakarta.jakartaee-web-api`), inconsistent `xsi:schemaLocation` (3 variants incl. a wrong host), hardcoded license year `2025`. |
| 🟠 Med | Orphaned PlantUML machinery — `build-plantuml` profile + Build.adoc section + `doc/images/*.png` with no `doc/plantuml/` sources. |
| 🟡 Low | Typo "plufins", stale wrapper/README docs, Markdown headers in an `.adoc` file, etc. |

## Proposed fix roadmap (in the doc)

Four small, independently-reviewable PRs:

- **PR-A** — CI/CD & Dependabot hygiene (contains the only functional defect)
- **PR-B** — POM cleanup (dead config, schemaLocation, typo)
- **PR-C** — Retire `license-cleanup` + fix license year
- **PR-D** — Documentation accuracy (independent, parallelisable)

Each finding in the doc lists file, line, fix hint, and a verify command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016VZmAmZYa1Ly1PXDvpixn9)_