### PR TITLE
chore: refresh CLAUDE.md and add /release skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: release
+description: Cut a cui-parent-pom release — bump .github/project.yml version and the README sample version, open and merge the release PR, wait for the automated Release workflow, verify the release landed, then reformat the generated GitHub release notes
+user-invocable: true
+allowed-tools: Bash, Read, Edit
+---
+
+# Release Skill
+
+Cuts a new `cui-parent-pom` (`de.cuioss:cui-parent-pom`) release end-to-end: determine the
+version, open the version-bump PR that triggers the release, merge it, wait for the automated
+Release workflow, verify the release landed, and reformat the auto-generated GitHub release
+notes.
+
+## How the release is wired (read first)
+
+The release is **fully automated by GitHub Actions**. `.github/workflows/release.yml` triggers
+on a **merged pull request that changes `.github/project.yml`**:
+
+```yaml
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - '.github/project.yml'
+```
+
+So this skill never runs Maven release goals by hand. Its job is to produce and merge the
+correct `project.yml` change; the reusable `cuioss-organization` release workflow
+(`reusable-maven-release.yml`, run with the `release-pom` profile) does the Maven release
+(`-DreleaseVersion=<current-version> -DdevelopmentVersion=<next-version>`), tagging, Maven
+Central deploy, GitHub release creation, and — because `pages.deploy-at-release: true` — the
+documentation pages deploy.
+
+This is a **POM-and-BOM aggregator** — there is no Java source, no tests, and no
+integration/e2e suites. The only PR gating check is the **Maven Build** matrix (Java 21).
+
+Observed timings:
+- PR gating check (**Maven Build**): typically **~1–3 min** (validate + enforcer only, no tests).
+- Release workflow: **~5 min**, but Maven Central propagation, the GitHub release publish, and
+  the pages deploy can lag → allow **up to ~30 min** before treating it as stuck.
+
+## Version scheme (differs from library repos)
+
+Read the release block in `.github/project.yml`:
+- `release.current-version` — the last released version, e.g. `1.4.5`
+- `release.next-version` — the rolling development version, held at `1.4-SNAPSHOT`
+
+**Default rule — patch bump.** The tag history is `1.4.0, 1.4.1, … 1.4.5`, and `next-version`
+stays `1.4-SNAPSHOT` across releases (the pom `<version>` is `1.4-SNAPSHOT`). To cut the next
+release, **increment the third segment of `current-version`** (`1.4.5` → `1.4.6`) and **leave
+`next-version` at `1.4-SNAPSHOT`**. Do **not** strip `-SNAPSHOT` from `next-version`
+(that would produce a lower version like `1.4`).
+
+**Ask the user** (AskUserQuestion) only if in doubt — e.g. a new minor line (`1.5.0`) or a
+major bump is intended, or `current-version`/tags look inconsistent. Otherwise state the
+determined version and proceed.
+
+## Workflow
+
+### Step 1 — Determine the version number
+From `project.yml`: release version = `current-version` with patch+1 (e.g. `1.4.6`).
+`next-version` is unchanged (`1.4-SNAPSHOT`).
+
+### Step 2 — Determine current status (clean to release?)
+```bash
+gh pr list --repo cuioss/cuioss-parent-pom --state open --json number,title,isDraft
+```
+- **No open PRs** → proceed.
+- **Open PRs exist** → surface the list and **ask the user** whether to proceed or wait. Do
+  not silently ignore them.
+
+Confirm the working tree is clean (`git status --porcelain`) before branching.
+
+### Step 3 — Pull current main
+```bash
+git checkout main && git pull --ff-only origin main
+```
+
+### Step 4 — Create the release branch
+Branch prefix **must** be a CI-accepted prefix (`main`, `feature/*`, `fix/*`, `chore/*`,
+`release/*`, `dependabot/**`) or the Maven Build check skips and auto-merge is blocked:
+```bash
+git checkout -b chore/release_<version>   # e.g. chore/release_1.4.6
+```
+
+### Step 5 — Update `.github/project.yml` and the README sample version
+1. Edit the `release` block in `.github/project.yml`:
+   - `current-version:` → the release version from Step 1 (e.g. `1.4.6`)
+   - `next-version:` → **unchanged** (`1.4-SNAPSHOT`)
+2. Update the parent-version sample in **`README.adoc`** (the `<version>…</version>` under the
+   `cui-java-parent` `<parent>` in the "Usage for Standard java-modules" snippet) to the new
+   release version, so the published docs show the released parent version. Then check for any
+   other stale references to the previous version in docs:
+   ```bash
+   grep -rn "<previous-version>" --include="*.adoc" .   # e.g. 1.4.5 — update sample references
+   ```
+   Do **not** touch `version.cui.parent` in `pom.xml` — the release plugin bumps it
+   automatically via `preparationGoals`.
+
+### Step 6 — Commit, push, open PR
+```bash
+git add .github/project.yml README.adoc
+git commit -m "chore(release): prepare release <version>"
+git push -u origin chore/release_<version>
+gh pr create --repo cuioss/cuioss-parent-pom --base main \
+  --title "chore(release): prepare release <version>" \
+  --body "Bump current-version to <version> (next-version stays 1.4-SNAPSHOT) and the README parent sample. Triggers the automated Release workflow on merge."
+```
+Commit trailer: `Co-Authored-By: Claude <noreply@anthropic.com>` (no model name, no
+"Generated with Claude Code" footer).
+
+### Step 7 — Wait for PR checks (~1–3 min)
+```bash
+gh pr checks <pr#> --repo cuioss/cuioss-parent-pom --watch
+```
+
+### Step 8 — Handle PR comments / failures (if any)
+- If a check fails, read the failing run's log (`gh run view <id> --log-failed`), fix on the
+  branch, push, re-wait. **Never** merge a red PR.
+- If the automated reviewer or a human leaves comments (`gh pr view <pr#> --comments`), address
+  them per the PR-comment protocol in `CLAUDE.md`: reply to and resolve every comment; ask the
+  user when uncertain.
+
+### Step 9 — Merge → release starts automatically
+```bash
+gh pr merge <pr#> --repo cuioss/cuioss-parent-pom --squash --delete-branch
+```
+Merging this PR (it touches `.github/project.yml`) fires `release.yml` automatically — do
+**not** dispatch the release manually unless the auto-trigger demonstrably did not fire.
+
+### Step 10 — Wait for the Release workflow (~30 min)
+```bash
+gh run list --repo cuioss/cuioss-parent-pom --workflow "Release" --limit 3 \
+  --json status,conclusion,displayTitle,databaseId
+gh run watch <databaseId> --repo cuioss/cuioss-parent-pom
+```
+
+### Step 11 — Verify the release landed
+```bash
+gh release view <version> --repo cuioss/cuioss-parent-pom --json tagName,name,createdAt,body
+git fetch --tags && git tag --list <version>
+```
+Confirm the tag exists and a GitHub release for `<version>` was created. If not, inspect the
+Release workflow run log before proceeding.
+
+### Step 12 — Reformat the generated release notes
+The Release workflow creates the GitHub release with **auto-generated** notes (a flat
+`## What's Changed` list). Rewrite them in place using the house format below, then push:
+```bash
+mkdir -p .plan/temp
+gh release view <version> --repo cuioss/cuioss-parent-pom --json body --jq .body > .plan/temp/release-<version>-orig.md
+# ...build the reformatted body in .plan/temp/release-<version>.md...
+gh release edit <version> --repo cuioss/cuioss-parent-pom --notes-file .plan/temp/release-<version>.md
+```
+
+#### House format rules (apply exactly)
+1. **Two top-level groups:** `## Features & Enhancements` and `## Dependency Updates`.
+2. **Features & Enhancements** — for a POM/BOM aggregator these are rare; group functional PRs
+   by theme with `###` subheadings when present, e.g. `### Build & Configuration`,
+   `### CI/CD & Workflows`, `### Documentation`. Omit empty sections.
+3. **Dependency Updates** — group by type with `###` subheadings:
+   - `### Java` — managed library version bumps in the BOMs (e.g. quarkus, myfaces, jakarta,
+     microprofile, cui-java-tools, cui-http)
+   - `### Infra` — build/CI: build-plugin bumps, `cuioss-organization` workflow bumps,
+     GitHub Actions bumps
+4. **Collapse version chains** — when the same artifact is bumped multiple times (`A → B → C`),
+   keep one entry spanning the full range (`A → C`).
+5. **Remove all OpenRewrite bumps and friends** — drop every `rewrite-maven-plugin`,
+   `rewrite-migrate-java`, `rewrite-testing-frameworks`, and related OpenRewrite PR.
+6. **Remove internal tooling churn** — drop PRs that only touch dev/build orchestration with no
+   user-facing effect, and the mechanical version-bump PR itself.
+7. Preserve each kept PR line verbatim (`* <title> by @author in <url>`); merge duplicate
+   titles onto one line with both URLs.
+8. Keep the trailing `**Full Changelog**: ...compare/<prev>...<version>` line.
+
+### Step 13 — Done
+Report: released version, release URL, the PR number, and how many dependency PRs were
+collapsed/removed during note reformatting.
+
+## Critical rules
+- The release is triggered by **merging a `.github/project.yml` change** — never hand-run Maven
+  release goals.
+- **Patch-bump `current-version`; keep `next-version` at `1.4-SNAPSHOT`.**
+- Always update the **README parent sample version** in the same PR; never touch
+  `version.cui.parent` (auto-bumped by the release plugin).
+- Branch prefix **must** be `chore/` (or another CI-accepted prefix) or the build check skips
+  and auto-merge is blocked.
+- Never merge a red PR; fix and re-wait.
+- Temporary files go under `.plan/temp/`.
+- Commit trailer: `Co-Authored-By: Claude <noreply@anthropic.com>`; no PR footer line.

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@ pom.xml.versionsBackup
 /deploy-setup.sh
 /settings.xml
 
-# Claude Code configuration
-.claude/
+# Claude Code configuration — ignore local settings, track shared skills/commands
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-cui-parent-pom is a Maven parent POM for CUI open-source Java projects. It provides standardized build configuration, dependency management, and development workflows for descendant projects.
+cui-parent-pom is a Maven parent POM for CUI open-source Java projects. It provides standardized build configuration, dependency management, and development workflows for descendant projects. It is a POM-and-BOM aggregator — there is no Java source in this repository.
 
 ## Key Commands
 
@@ -20,21 +20,20 @@ cui-parent-pom is a Maven parent POM for CUI open-source Java projects. It provi
 ./mvnw -Ppre-commit
 ```
 
-### Release Process
-```bash
-# Prepare release
-./mvnw -Prelease-pom release:clean release:prepare -DreleaseVersion=X.Y.Z -DdevelopmentVersion=X.Y.Z-SNAPSHOT
+### Releasing
+Releases are **fully automated by GitHub Actions**. Merging a pull request that changes
+`.github/project.yml` triggers `.github/workflows/release.yml` (the reusable
+`cuioss-organization` maven-release workflow), which runs the Maven release goals, tags,
+deploys to Maven Central, creates the GitHub release, and — because `pages.deploy-at-release`
+is set — deploys the documentation site.
 
-# Perform release
-./mvnw -Prelease-pom release:perform
-
-# Deploy snapshot
-./mvnw -B --no-transfer-progress deploy
-```
+Use the **`/release` skill** (`.claude/skills/release/`) to cut a release: it determines the
+version, opens and merges the version-bump PR, waits for the release workflow, and reformats
+the generated release notes. Do **not** hand-run `release:prepare`/`release:perform`.
 
 ### Other Useful Commands
 ```bash
-# Generate PlantUML diagrams
+# Generate PlantUML diagrams (add sources under doc/plantuml/*.puml first)
 ./mvnw generate-resources -Pbuild-plantuml
 
 # Generate Maven site
@@ -42,6 +41,9 @@ cui-parent-pom is a Maven parent POM for CUI open-source Java projects. It provi
 
 # Get current version
 ./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout
+
+# Deploy a SNAPSHOT (normally done automatically on main by CI)
+./mvnw -B --no-transfer-progress deploy
 ```
 
 ## Architecture and Structure
@@ -52,7 +54,7 @@ cui-parent-pom (root)
 ├── cui-java-bom (Java dependency management)
 │   └── cui-java-parent (Parent POM for simple Java projects)
 └── java-ee-bom (Jakarta EE dependency management)
-    ├── java-ee-10-bom (Jakarta EE 10 specific)
+    ├── java-ee-10-bom (Jakarta EE 10 module; forward-adopts some EE 11 APIs)
     │   └── quarkus-bom (Quarkus framework)
     └── java-ee-orthogonal (Cross-cutting EE concerns)
 ```
@@ -67,18 +69,21 @@ cui-parent-pom (root)
 ### Important Profiles
 
 - **pre-commit**: Applies license headers and OpenRewrite formatting
-- **release-pom**: Used for releasing POM-only artifacts (no Java code)
-- **release**: Used for releasing Java artifacts with sources and javadocs
+- **coverage**: Local JaCoCo coverage analysis with thresholds
+- **release-pom**: Used for releasing POM-only artifacts (no Java code); the release workflow uses this profile (`maven-profiles-release` in `project.yml`)
+- **release** / **release-snapshot**: Java-artifact release / snapshot profiles
+- **javadoc**: Javadoc generation
 - **sonar**: Enables SonarCloud analysis with JaCoCo coverage
-- **build-plantuml**: Generates PNG images from PlantUML diagrams
+- **build-plantuml**: Generates PNG images from PlantUML `.puml` sources under `doc/plantuml/`
 
 ### Critical Configuration
 
 1. **Java Version**: Requires Java 21 or higher (enforced by maven-enforcer-plugin)
-2. **Maven Version**: Requires Maven 3.8.0+ (3.9.6 via wrapper)
-3. **License Headers**: Apache 2.0 license, recently changed from javadoc to regular comment style
-4. **Deployment**: Uses new central-publishing-maven-plugin for Sonatype/Maven Central
-5. **Reproducible Builds**: Configured with project.build.outputTimestamp
+2. **Maven Version**: Requires Maven 3.8.0+ (3.9.6 via the `maven-wrapper-plugin`, `distributionType=only-script`)
+3. **License Headers**: Apache 2.0 license in regular comment style (`/* */`), stamped by the mycila `license-maven-plugin` (current year, no hardcoded year override)
+4. **Deployment**: Uses the `central-publishing-maven-plugin` for Sonatype/Maven Central
+5. **Reproducible Builds**: Configured with `project.build.outputTimestamp`
+6. **Parent version property**: `version.cui.parent` (root `pom.xml`) holds the released parent version; the release plugin bumps it automatically via `preparationGoals`. Consumers import BOMs with `${version.cui.parent}`.
 
 ### Development Guidelines
 
@@ -88,27 +93,28 @@ cui-parent-pom (root)
 4. **Validating Changes**: Always run `./mvnw verify` to ensure all modules build correctly
 5. **Module Structure**: New modules should follow the existing hierarchy pattern
 
-### Recent Changes
-
-The project changed license headers from javadoc style (`/** */`) to regular comment style (`/* */`) to avoid IDE warnings.
-
 ### CI/CD Integration
 
-- GitHub Actions workflows handle builds, tests, and deployments
-- Automatic SNAPSHOT deployments on main branch commits
-- Release workflow triggered by changes to project.yml
-- Security scanning via GitHub security features and scorecards
+- GitHub Actions workflows are **thin callers** to the reusable workflows in
+  `cuioss/cuioss-organization` (pinned by SHA, currently `v0.7.0`). Per-repo configuration
+  lives in `.github/project.yml`.
+  - `maven.yml` → `reusable-maven-build.yml` (build + Sonar + snapshot deploy; path filtering handled inside the reusable workflow)
+  - `release.yml` → `reusable-maven-release.yml` (triggered by a merged `project.yml` change)
+  - `dependency-review.yml`, `dependabot-auto-merge.yml`, `scorecards.yml` → their reusable counterparts
+- Automatic SNAPSHOT deployments on `main` commits.
+- Dependabot updates (maven + github-actions) with a tiered `cooldown`.
+- Supply-chain hardening via OpenSSF Scorecard; all actions pinned by commit SHA.
 
 ## Git Workflow
 
 All cuioss repositories have branch protection on `main`. Direct pushes to `main` are never allowed. Always use this workflow:
 
-1. Create a feature branch: `git checkout -b <branch-name>`
+1. Create a feature branch: `git checkout -b <branch-name>` (use a CI-recognized prefix: `feature/`, `fix/`, `chore/`, `release/`)
 2. Commit changes: `git add <files> && git commit -m "<message>"`
 3. Push the branch: `git push -u origin <branch-name>`
 4. Create a PR: `gh pr create --repo cuioss/cuioss-parent-pom --head <branch-name> --base main --title "<title>" --body "<body>"`
-5. Wait for CI + Gemini review (waits until checks complete): `gh pr checks --watch`
-6. **Handle Gemini review comments** — fetch with `gh api repos/cuioss/cuioss-parent-pom/pulls/<pr-number>/comments` and for each:
+5. Wait for CI + automated review (waits until checks complete): `gh pr checks --watch`
+6. **Handle review comments** — fetch with `gh api repos/cuioss/cuioss-parent-pom/pulls/<pr-number>/comments` and for each:
    - If clearly valid and fixable: fix it, commit, push, then reply explaining the fix and resolve the comment
    - If disagree or out of scope: reply explaining why, then resolve the comment
    - If uncertain (not 100% confident): **ask the user** before acting


### PR DESCRIPTION
## CLAUDE.md refresh
Brings the guidance in line with current reality:
- **Releasing** section rewritten: releases are automated by merging a `.github/project.yml` change (reusable `cuioss-organization` maven-release workflow); documents the new `/release` skill and drops the stale manual `release:prepare`/`release:perform` instructions.
- **CI/CD** section describes the thin-caller model — each workflow calls a `cuioss-organization` reusable workflow (SHA-pinned, v0.7.0), config in `.github/project.yml`.
- Profile list corrected; `version.cui.parent` role, `maven-wrapper-plugin`, and current-year license stamping noted.

## /release skill
Adds `.claude/skills/release/SKILL.md`, adapted from cuioss/cui-http#83 and tailored to this repo:
- **Patch-bump scheme:** release = `current-version` patch+1 (`1.4.5` → `1.4.6`); `next-version` stays `1.4-SNAPSHOT` (do not strip `-SNAPSHOT`).
- The release-prep PR also bumps the **README parent sample version**; `version.cui.parent` is left to the release plugin's `preparationGoals`.
- Drives the automated project.yml-bump → `release.yml` path; never hand-runs Maven goals.

## .gitignore
Scopes the ignore to `.claude/settings.local.json` only, so shared skills are tracked (mirrors cui-http). Local settings stay ignored.