### PR TITLE
docs: full review of README/doc structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ cui-parent-pom is a Maven parent POM for CUI open-source Java projects. It provi
 ./mvnw clean install
 
 # Run pre-commit tasks (license headers + formatting)
-./mvnw -Ppre-commit
+./mvnw -Ppre-commit verify
 ```
 
 ### Releasing
@@ -89,7 +89,7 @@ cui-parent-pom (root)
 
 1. **Adding Dependencies**: Define versions as properties in the appropriate BOM module
 2. **Plugin Configuration**: Add to pluginManagement in root POM with version property
-3. **License Headers**: Run `./mvnw -Ppre-commit` before committing to ensure proper headers
+3. **License Headers**: Run `./mvnw -Ppre-commit verify` before committing to ensure proper headers
 4. **Validating Changes**: Always run `./mvnw verify` to ensure all modules build correctly
 5. **Module Structure**: New modules should follow the existing hierarchy pattern
 

--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@
 [.discrete]
 == Status
 
-image:https://github.com/cuioss/cui-parent-pom/actions/workflows/maven.yml/badge.svg[Java CI with Maven,link=https://github.com/cuioss/cui-parent-pom/actions/workflows/maven.yml]
+image:https://github.com/cuioss/cuioss-parent-pom/actions/workflows/maven.yml/badge.svg[Java CI with Maven,link=https://github.com/cuioss/cuioss-parent-pom/actions/workflows/maven.yml]
 image:http://img.shields.io/:license-apache-blue.svg[License,link=http://www.apache.org/licenses/LICENSE-2.0.html]
 image:https://img.shields.io/maven-central/v/de.cuioss/cui-parent-pom.svg?label=Maven%20Central["Maven Central", link="https://central.sonatype.com/artifact/de.cuioss/cui-parent-pom"]
 
@@ -23,7 +23,12 @@ toc::[]
 
 * link:cui-java-bom/README.adoc[cui-java-bom] - Java dependency management
 * link:java-ee-bom/README.adoc[java-ee-bom] - Jakarta EE dependency management
-* link:doc/Build.adoc[Build Information] - Information about building the project
+
+== Documentation
+
+* link:doc/Build.adoc[Build Information] - Building the project, reproducible builds, PlantUML
+* link:doc/open-rewrite-recipes.adoc[OpenRewrite Recipes] - Code modernization and formatting recipes (pre-commit profile)
+* link:doc/signing_key.adoc[Signing Keys] - Creating the GPG signing key for Maven Central
 
 == Usage
 
@@ -34,7 +39,7 @@ toc::[]
 <parent>
    <groupId>de.cuioss</groupId>
    <artifactId>cui-parent-pom</artifactId>
-   <version>${version}</version>
+   <version>1.4.5</version> <!-- use the latest release -->
 </parent>
 ----
 
@@ -47,7 +52,7 @@ toc::[]
         <dependency>
             <groupId>de.cuioss</groupId>
             <artifactId>java-ee-10-bom</artifactId>
-            <!-- Starting with 0.9.8 version.cui.parent will be implicitly set by cui-parent-pom -->
+            <!-- version.cui.parent is set implicitly by cui-parent-pom; override only if needed -->
             <version>${version.cui.parent}</version>
             <type>pom</type>
             <scope>import</scope>
@@ -60,7 +65,7 @@ toc::[]
 
 [source,xml]
 ----
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>de.cuioss</groupId>

--- a/cui-java-bom/README.adoc
+++ b/cui-java-bom/README.adoc
@@ -10,7 +10,7 @@ Provides a number of standard-java dependency-declarations that can be consumed 
 
 To use this BOM in your project, add it to your dependencyManagement section:
 
-[source, xml]
+[source,xml]
 ----
 <dependencyManagement>
     <dependencies>
@@ -29,12 +29,14 @@ This BOM includes managed dependencies for:
 
 * Standard Java libraries
 * Project Lombok
+* JSpecify (null-safety annotations)
 * JDOM2
 * CUI Java Tools
 * CUI Core UI Model
+* CUI HTTP
 * Testing frameworks:
   * JUnit 5
   * Hamcrest
   * EasyMock
-  * CUI Test utilities
+  * CUI Test utilities (generator, value-objects, juli-logger, mockwebserver-junit5)
   * Awaitility

--- a/cui-java-bom/cui-java-parent/README.adoc
+++ b/cui-java-bom/cui-java-parent/README.adoc
@@ -6,12 +6,12 @@ Parent pom for simple java-projects. Provides configuration for Java projects wi
 
 To use this parent POM in your project, add it to your pom.xml:
 
-[source, xml]
+[source,xml]
 ----
 <parent>
     <groupId>de.cuioss</groupId>
     <artifactId>cui-java-parent</artifactId>
-    <version>${version}</version>
+    <version>1.4.5</version> <!-- use the latest release -->
 </parent>
 ----
 

--- a/doc/Build.adoc
+++ b/doc/Build.adoc
@@ -24,7 +24,7 @@ This project implements several measures to ensure reproducible builds. The foll
  
 * All plugin and dependency versions are pinned in all `pom.xml` files. No LATEST, RELEASE, or version ranges are used.
 * The Maven Wrapper is present (`mvnw`, `mvnw.cmd`, `.mvn/wrapper/maven-wrapper.properties`) and pins Maven `3.9.6`.
-* Java version is set explicitly in the root `pom.xml`, inherited by all modules.:
+* Java version is set explicitly in the root `pom.xml`, inherited by all modules:
 
 [source,xml]
 ----
@@ -48,13 +48,15 @@ The project includes a convenient `pre-commit` profile that combines license hea
 
 [source,shell]
 ----
-./mvnw -Ppre-commit
+./mvnw -Ppre-commit verify
 ----
 
 This profile performs the following tasks:
 
 1. Adds or updates Apache 2.0 license headers to source files
 2. Applies all configured OpenRewrite recipes for code modernization and formatting
+
+See link:open-rewrite-recipes.adoc[OpenRewrite Recipes] for the full list of recipes applied.
 
 == PlantUML Diagrams
 

--- a/doc/open-rewrite-recipes.adoc
+++ b/doc/open-rewrite-recipes.adoc
@@ -8,7 +8,7 @@ The project includes a `pre-commit` profile that combines license header managem
 
 [source,shell]
 ----
-./mvnw -Ppre-commit clean verify -DskipTests
+./mvnw -Ppre-commit verify
 ----
 
 This profile applies all the recipes listed below and also manages license headers.

--- a/doc/signing_key.adoc
+++ b/doc/signing_key.adoc
@@ -15,7 +15,7 @@ Starting with Jose Carvajal excellent introduction: https://sgitario.github.io/d
 * Generate a new key-par using 'gpg --generate-key'
 * gpg --list-keys:
 
-[source,json]
+[source,text]
 ----
 pub   rsa3072 2022-12-04 [SC] [verfällt: 2026-12-03]
       D6A0*****
@@ -24,15 +24,21 @@ sub   rsa3072 2022-12-04 [E] [verfällt: 2026-12-03]
 ----
 * gpg --keyserver keyserver.ubuntu.com --send-keys D6A0*****
 Optional, to speed things up, not strictly necessary:
-* gpg --keyserver eys.openpgp.org --send-keys D6A0*****
+* gpg --keyserver keys.openpgp.org --send-keys D6A0*****
 * gpg --keyserver pgp.mit.edu --send-keys D6A0*****
 
 === Export Key to clipboard
 ==== macOS
+[source,shell]
+----
 gpg --armor --export-secret-key joe@foo.bar | pbcopy
+----
 
-===== Ubuntu (assuming GNU base64)
+==== Ubuntu (assuming GNU base64)
+[source,shell]
+----
 gpg --armor --export-secret-key joe@foo.bar -w0 | xclip
+----
 
 == Open Tasks / Todos
 

--- a/java-ee-bom/README.adoc
+++ b/java-ee-bom/README.adoc
@@ -4,30 +4,16 @@ Aggregates the different java-ee versions. This module serves as a parent for Ja
 
 This module is part of the link:../README.adoc[cui-parent-pom] project.
 
-== Submodules
+== Modules
 
 This parent module includes the following submodules:
 
-* link:java-ee-10-bom/README.adoc[java-ee-10-bom]: Bundles all Java EE 10 related dependencies
+* link:java-ee-10-bom/README.adoc[java-ee-10-bom]: Bundles all Jakarta EE 10 related dependencies
 * link:java-ee-orthogonal/README.adoc[java-ee-orthogonal]: Libraries that are used in the Jakarta EE context but are agnostic to the actual version
 
 == Usage
 
-To use this BOM in your project, add it to your dependencyManagement section:
+This module is a pure aggregator/parent — it declares no managed dependencies of its own, and importing it as a BOM would import nothing (Maven does not import a BOM's submodules transitively). Import the concrete BOM(s) you need instead:
 
-[source, xml]
-----
-<dependencyManagement>
-    <dependencies>
-        <dependency>
-            <groupId>de.cuioss</groupId>
-            <artifactId>java-ee-bom</artifactId>
-            <version>${version}</version>
-            <type>pom</type>
-            <scope>import</scope>
-        </dependency>
-    </dependencies>
-</dependencyManagement>
-----
-
-This will import all the managed dependencies from both the java-ee-10-bom and java-ee-orthogonal modules.
+* link:java-ee-10-bom/README.adoc[java-ee-10-bom]
+* link:java-ee-orthogonal/README.adoc[java-ee-orthogonal]

--- a/java-ee-bom/java-ee-10-bom/README.adoc
+++ b/java-ee-bom/java-ee-10-bom/README.adoc
@@ -1,6 +1,8 @@
 = java ee-10-bom
 
-Bundles all Java EE 10 related dependencies. This Bill of Materials (BOM) provides managed dependencies for Jakarta EE 10 applications, including JSF components, MicroProfile implementations, and related libraries.
+Bundles all Jakarta EE 10 related dependencies. This Bill of Materials (BOM) provides managed dependencies for Jakarta EE 10 applications, including JSF components, MicroProfile implementations, and related libraries.
+
+NOTE: This module forward-adopts selected Jakarta EE 11 APIs (web-api `11.0.0`, servlet `6.1.0`) while remaining the "EE 10" baseline for CUI projects.
 
 This module is part of the link:../README.adoc[java-ee-bom] module.
 
@@ -8,7 +10,7 @@ This module is part of the link:../README.adoc[java-ee-bom] module.
 
 To use this BOM in your project, add it to your dependencyManagement section:
 
-[source, xml]
+[source,xml]
 ----
 <dependencyManagement>
     <dependencies>
@@ -32,4 +34,6 @@ This BOM includes managed dependencies for:
 * Weld (CDI Implementation)
 * MicroProfile APIs and implementations
 * RESTEasy
-* Quarkus integration components
+* Parsson (Jakarta JSON implementation)
+
+Quarkus dependencies are managed separately in the link:quarkus-bom/README.adoc[quarkus-bom] submodule.

--- a/java-ee-bom/java-ee-10-bom/quarkus-bom/README.adoc
+++ b/java-ee-bom/java-ee-10-bom/quarkus-bom/README.adoc
@@ -8,7 +8,7 @@ This module is part of the link:../README.adoc[java-ee-10-bom] module.
 
 To use this BOM in your project, add it to your dependencyManagement section:
 
-[source, xml]
+[source,xml]
 ----
 <dependencyManagement>
     <dependencies>
@@ -22,4 +22,13 @@ To use this BOM in your project, add it to your dependencyManagement section:
     </dependencies>
 </dependencyManagement>
 ----
+
+This BOM includes managed dependencies for:
+
+* Quarkus platform BOM (io.quarkus:quarkus-bom)
+* MyFaces Quarkus extension
+* Quarkus OmniFaces
+* Quarkus PrimeFaces
+
+It also manages the `quarkus-maven-plugin`.
 

--- a/java-ee-bom/java-ee-orthogonal/README.adoc
+++ b/java-ee-bom/java-ee-orthogonal/README.adoc
@@ -8,7 +8,7 @@ This module is part of the link:../README.adoc[java-ee-bom] module.
 
 To use this BOM in your project, add it to your dependencyManagement section:
 
-[source, xml]
+[source,xml]
 ----
 <dependencyManagement>
     <dependencies>
@@ -33,7 +33,6 @@ This BOM includes managed dependencies for:
 * Apache HttpCore
 * Log4j
 * SmallRye JWT
-* Parsson (JSON implementation)
+* BouncyCastle (bcprov/bcpkix)
 * REST Assured
-* CUI JWT Token Handling
 * CUI Test Keycloak Integration


### PR DESCRIPTION
Full documentation review across all READMEs and `doc/*.adoc`, cross-checked against the poms. Evaluated for correctness, completeness, consistency, duplication, and ambiguity.

## Correctness (the high-value fixes)
- **`java-ee-bom/README`**: it declares no `dependencyManagement` of its own — importing it as a BOM imports nothing (Maven doesn't import a BOM's submodules transitively). Replaced the misleading import example with pointers to the concrete child BOMs.
- **`java-ee-orthogonal/README`**: removed **Parsson** (actually managed in `java-ee-10-bom`) and the non-existent **"CUI JWT Token Handling"**; added **BouncyCastle** (actually managed).
- **`java-ee-10-bom/README`**: removed "Quarkus integration components" (they live in the `quarkus-bom` submodule, not imported transitively); added Parsson; noted the Jakarta EE 11 forward-adoption.
- **`cui-java-bom/README`**: added the managed **CUI HTTP** and **JSpecify** entries.
- **`quarkus-bom/README`**: added the previously-missing managed-dependency list.
- **root `README`**: CI badge pointed at the old repo name `cui-parent-pom` (301 redirect) → canonical `cuioss-parent-pom`; sample POM `schemaLocation` `http` → `https`; concrete parent version in the "As a parent POM" example.
- **`signing_key.adoc`**: keyserver typo `eys.openpgp.org` → `keys.openpgp.org`.

## Consistency & command correctness
- Standardized the pre-commit invocation to `./mvnw -Ppre-commit verify` (the bare `./mvnw -Ppre-commit` fails with "No goals have been specified") across `Build.adoc`, `open-rewrite-recipes.adoc`, and `CLAUDE.md`.
- Normalized `[source, xml]` → `[source,xml]`; "Java EE" → "Jakarta EE"; `== Submodules` → `== Modules`; fixed a stray `.:`.
- `signing_key.adoc`: aligned OS heading levels, wrapped commands in source blocks, relabeled the non-JSON gpg output.

## Links / duplication
- Added a **Documentation** section to the root README linking `Build.adoc`, `open-rewrite-recipes.adoc`, and `signing_key.adoc` (the latter two were previously orphaned); cross-linked Build.adoc's pre-commit section to the recipes doc.

_Deliberately kept:_ the per-module BOM-import usage snippets (self-contained value outweighs the duplication); the `${version}` placeholder in module BOM-import examples (consistent convention). No pom changes — docs only.