### PR TITLE
chore(release): prepare release 1.5.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -2,8 +2,8 @@ name: cui parent pom
 description: Parent pom for all CUI-OSS projects
 
 release:
-  current-version: 1.4.5
-  next-version: 1.4-SNAPSHOT
+  current-version: 1.5.0
+  next-version: 1.5-SNAPSHOT
   create-github-release: true
 
 maven-build:
@@ -42,7 +42,7 @@ consumers:
   - cui-test-keycloak-integration
   - cui-test-mockwebserver-junit5
   - cui-test-value-objects
-  - OAuthSheriff
+  - TokenSheriff
 
 dependency-propagation:
   group-id: de.cuioss

--- a/README.adoc
+++ b/README.adoc
@@ -39,7 +39,7 @@ toc::[]
 <parent>
    <groupId>de.cuioss</groupId>
    <artifactId>cui-parent-pom</artifactId>
-   <version>1.4.5</version> <!-- use the latest release -->
+   <version>1.5.0</version> <!-- use the latest release -->
 </parent>
 ----
 
@@ -70,7 +70,7 @@ toc::[]
     <parent>
         <groupId>de.cuioss</groupId>
         <artifactId>cui-java-parent</artifactId>
-        <version>1.4.5</version>
+        <version>1.5.0</version>
     </parent>
     <artifactId>cui-java-sample</artifactId>
     <name>cui java sample</name>


### PR DESCRIPTION
Cuts release **1.5.0** (opens the 1.5 minor line) and renames the stale consumer `OAuthSheriff` → `TokenSheriff`.

- `project.yml`: `current-version` 1.4.5 → **1.5.0**, `next-version` 1.4-SNAPSHOT → **1.5-SNAPSHOT**
- `README.adoc`: parent-version samples 1.4.5 → 1.5.0
- consumers: `OAuthSheriff` → `TokenSheriff` (list stays alphabetically sorted)

Merging this triggers the automated Release workflow (reusable `cuioss-organization` maven-release). The reactor pom versions and `version.cui.parent` are bumped by the release plugin and force-pushed to `main` — intentionally not touched here.

Labeled `skip-coderabbit` (central CodeRabbit config exclusion).