### PR TITLE
chore(release): prepare release 1.5.1

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -106,7 +106,7 @@ git push -u origin chore/release_<version>
 gh pr create --repo cuioss/cuioss-parent-pom --base main \
   --title "chore(release): prepare release <version>" \
   --label "skip-bot-review" \
-  --body "Bump current-version to <version> (next-version stays 1.5-SNAPSHOT) and the README parent sample. Triggers the automated Release workflow on merge."
+  --body "Bump current-version to <version> (next-version stays <next-version>) and the README parent sample. Triggers the automated Release workflow on merge."
 ```
 Apply the **`skip-bot-review`** label (via `--label "skip-bot-review"` on `gh pr create`, or
 `gh pr edit <pr#> --add-label "skip-bot-review"` if the PR already exists). A mechanical

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -105,8 +105,14 @@ git commit -m "chore(release): prepare release <version>"
 git push -u origin chore/release_<version>
 gh pr create --repo cuioss/cuioss-parent-pom --base main \
   --title "chore(release): prepare release <version>" \
-  --body "Bump current-version to <version> (next-version stays 1.4-SNAPSHOT) and the README parent sample. Triggers the automated Release workflow on merge."
+  --label "skip-bot-review" \
+  --body "Bump current-version to <version> (next-version stays 1.5-SNAPSHOT) and the README parent sample. Triggers the automated Release workflow on merge."
 ```
+Apply the **`skip-bot-review`** label (via `--label "skip-bot-review"` on `gh pr create`, or
+`gh pr edit <pr#> --add-label "skip-bot-review"` if the PR already exists). A mechanical
+release-prep PR only changes the `project.yml` version and the README sample — no bot review is
+necessary, and the label suppresses the automated reviewers (CodeRabbit / Sourcery).
+
 Commit trailer: `Co-Authored-By: Claude <noreply@anthropic.com>` (no model name, no
 "Generated with Claude Code" footer).
 

--- a/.github/project.yml
+++ b/.github/project.yml
@@ -2,7 +2,7 @@ name: cui parent pom
 description: Parent pom for all CUI-OSS projects
 
 release:
-  current-version: 1.5.0
+  current-version: 1.5.1
   next-version: 1.5-SNAPSHOT
   create-github-release: true
 

--- a/README.adoc
+++ b/README.adoc
@@ -39,7 +39,7 @@ toc::[]
 <parent>
    <groupId>de.cuioss</groupId>
    <artifactId>cui-parent-pom</artifactId>
-   <version>1.5.0</version> <!-- use the latest release -->
+   <version>1.5.1</version> <!-- use the latest release -->
 </parent>
 ----
 
@@ -70,7 +70,7 @@ toc::[]
     <parent>
         <groupId>de.cuioss</groupId>
         <artifactId>cui-java-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1</version>
     </parent>
     <artifactId>cui-java-sample</artifactId>
     <name>cui java sample</name>


### PR DESCRIPTION
Bump current-version to 1.5.1 (next-version stays 1.5-SNAPSHOT) and the README parent samples. Triggers the automated Release workflow on merge.

Also adds the `skip-bot-review` label to the release skill's PR-creation step: a mechanical release-prep PR only touches the version and README sample, so no automated bot review is necessary.