### PR TITLE
chore(steward): initialize plan-marshall project configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ pom.xml.versionsBackup
 
 # Claude Code configuration — ignore local settings, track shared skills/commands
 .claude/settings.local.json
+
+# Planning system (managed by /marshall-steward)
+# Runtime state (plans, run-configuration, lessons-learned, memory, logs — managed by plan-marshall)
+.plan/*
+!.plan/marshal.json
+!.plan/project-architecture/

--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -1,0 +1,188 @@
+{
+  "plan": {
+    "effort": "level-3",
+    "open_in_ide": true,
+    "coverage": {
+      "thoroughness": "inherit",
+      "scope": "inherit"
+    },
+    "finding_raw_input_max_bytes": 65536,
+    "phase-1-init": {
+      "branch_strategy": "feature",
+      "use_worktree": true,
+      "init_without_asking": true,
+      "deep_lane": "auto",
+      "escalation": "auto",
+      "auto_route_recipe": true,
+      "auto_route_recipe_threshold": 0.6,
+      "lane_selection": "ask",
+      "lane_prune_thresholds": {
+        "confidence_complete": 95,
+        "linear_change_max_deliverables": 1
+      }
+    },
+    "phase-2-refine": {
+      "confidence_threshold": 95,
+      "compatibility": "breaking",
+      "simplicity": "lean",
+      "effort": "level-3",
+      "revalidation": "auto"
+    },
+    "phase-3-outline": {
+      "plan_without_asking": false,
+      "q_gate_validation": "once",
+      "effort": "level-4"
+    },
+    "phase-4-plan": {
+      "execute_without_asking": true,
+      "q_gate_validation": "once",
+      "effort": "level-3"
+    },
+    "phase-5-execute": {
+      "commit_and_push": true,
+      "max_iterations": 5,
+      "per_deliverable_build": [
+        "default:verify:compile",
+        "default:verify:module-tests"
+      ],
+      "cost_size_token_table": {
+        "XS": "5K",
+        "S": "25K",
+        "M": "60K",
+        "L": "130K",
+        "XL": "260K",
+        "XXL": "520K"
+      },
+      "per_envelope_budget_tokens": "400K",
+      "verification_steps": {
+        "default:verify:quality-gate": {},
+        "default:verify:module-tests": {},
+        "default:verify:coverage": {}
+      },
+      "effort": {
+        "default": "level-4",
+        "verification-feedback": "level-3"
+      }
+    },
+    "phase-6-finalize": {
+      "max_iterations": 3,
+      "finalize_without_asking": true,
+      "loop_back_without_asking": false,
+      "checks_wait_timeout_seconds": 600,
+      "steps": {
+        "default:push": {},
+        "default:create-pr": {},
+        "default:ci-verify": {},
+        "plan-marshall:automatic-review": {
+          "enabled_bots": "coderabbit,sourcery,gemini",
+          "review_bot_buffer_seconds": 180,
+          "review_completion_poll_timeout_seconds": 600,
+          "re_review_on_loopback": false,
+          "re_review_on_branch_cleanup": true,
+          "re_review_await_timeout_seconds": 600,
+          "re_review_on_timeout": "ask",
+          "review_rate_window_await": false,
+          "review_rate_window_timeout_seconds": 3600,
+          "lane": "off"
+        },
+        "default:lessons-capture": {},
+        "default:branch-cleanup": {
+          "pr_merge_strategy": "squash",
+          "final_merge_without_asking": false,
+          "auto_rebase_threshold": "no_overlap_only",
+          "merge_queue_wait_budget_seconds": 1800,
+          "merge_hold_window": "full_window_release_at_waits",
+          "merge_hold_budget_seconds": 3600,
+          "use_merge_queue": true,
+          "admin_merge_on_stuck_state": false,
+          "pre_merge_comment_barrier": "fail_into_loopback"
+        },
+        "default:record-metrics": {},
+        "default:archive-plan": {}
+      },
+      "effort": {
+        "default": "level-3",
+        "verification-feedback": "level-3",
+        "post-run-review": "level-4"
+      }
+    }
+  },
+  "build": {
+    "queue": {
+      "max_slots": 5,
+      "max_retries": 10,
+      "upper_limit_seconds": 600
+    },
+    "map": {
+      "java": [
+        {
+          "glob": "pom.xml",
+          "role": "config",
+          "build_class": "verify"
+        }
+      ]
+    }
+  },
+  "project": {
+    "default_base_branch": "main",
+    "working_prefixes": [
+      "feature/",
+      "fix/",
+      "chore/"
+    ],
+    "pr_strategy": "compact",
+    "pr_compact_max_changed_files": 150
+  },
+  "providers": [
+    {
+      "skill_name": "plan-marshall:workflow-integration-github",
+      "category": "ci",
+      "verify_command": "gh auth status",
+      "description": "GitHub CI provider via gh CLI — PRs, issues, CI status, reviews",
+      "url": "https://api.github.com"
+    },
+    {
+      "skill_name": "plan-marshall:workflow-integration-git",
+      "category": "version-control",
+      "verify_command": "git config user.name",
+      "description": "Git version control via git CLI — commit, push, branch operations",
+      "url": "https://github.com/cuioss/cuioss-parent-pom.git"
+    }
+  ],
+  "skill_domains": {
+    "system": {
+      "defaults": [],
+      "optionals": []
+    },
+    "documentation": {
+      "bundle": "pm-documents",
+      "workflow_skill_extensions": {
+        "triage": "pm-documents:ext-triage-docs"
+      }
+    },
+    "java": {
+      "bundle": "pm-dev-java",
+      "workflow_skill_extensions": {
+        "triage": "pm-dev-java:ext-triage-java"
+      }
+    },
+    "general-dev": {
+      "bundle": "plan-marshall"
+    },
+    "active_profiles": [
+      "implementation",
+      "module_testing",
+      "quality"
+    ]
+  },
+  "system": {
+    "retention": {
+      "logs_days": 1,
+      "archived_plans_days": 5,
+      "lessons_superseded_days": 0,
+      "temp_on_maintenance": true
+    },
+    "provisioned_version": "0.1.1132",
+    "config_seed_fingerprint": "37df1a33"
+  }
+}

--- a/.plan/project-architecture/_project.json
+++ b/.plan/project-architecture/_project.json
@@ -1,0 +1,19 @@
+{
+  "description": "",
+  "description_reasoning": "",
+  "extensions_used": [
+    "plan-marshall",
+    "pm-documents"
+  ],
+  "modules": {
+    "cui-java-bom": {},
+    "cui-java-parent": {},
+    "cui-parent-pom": {},
+    "documentation": {},
+    "java-ee-10-bom": {},
+    "java-ee-bom": {},
+    "java-ee-orthogonal": {},
+    "quarkus-bom": {}
+  },
+  "name": "cuioss-parent-pom"
+}

--- a/.plan/project-architecture/cui-java-bom/enriched.json
+++ b/.plan/project-architecture/cui-java-bom/enriched.json
@@ -1,0 +1,79 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {},
+  "purpose": "",
+  "purpose_reasoning": "",
+  "responsibility": "",
+  "responsibility_reasoning": "",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/.plan/project-architecture/cui-java-parent/enriched.json
+++ b/.plan/project-architecture/cui-java-parent/enriched.json
@@ -1,0 +1,79 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {},
+  "purpose": "",
+  "purpose_reasoning": "",
+  "responsibility": "",
+  "responsibility_reasoning": "",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/.plan/project-architecture/cui-parent-pom/enriched.json
+++ b/.plan/project-architecture/cui-parent-pom/enriched.json
@@ -1,0 +1,79 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {},
+  "purpose": "",
+  "purpose_reasoning": "",
+  "responsibility": "",
+  "responsibility_reasoning": "",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/.plan/project-architecture/documentation/enriched.json
+++ b/.plan/project-architecture/documentation/enriched.json
@@ -1,0 +1,15 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {},
+  "purpose": "",
+  "purpose_reasoning": "",
+  "responsibility": "",
+  "responsibility_reasoning": "",
+  "skills_by_profile": {},
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/.plan/project-architecture/java-ee-10-bom/enriched.json
+++ b/.plan/project-architecture/java-ee-10-bom/enriched.json
@@ -1,0 +1,79 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {},
+  "purpose": "",
+  "purpose_reasoning": "",
+  "responsibility": "",
+  "responsibility_reasoning": "",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/.plan/project-architecture/java-ee-bom/enriched.json
+++ b/.plan/project-architecture/java-ee-bom/enriched.json
@@ -1,0 +1,79 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {},
+  "purpose": "",
+  "purpose_reasoning": "",
+  "responsibility": "",
+  "responsibility_reasoning": "",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/.plan/project-architecture/java-ee-orthogonal/enriched.json
+++ b/.plan/project-architecture/java-ee-orthogonal/enriched.json
@@ -1,0 +1,79 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {},
+  "purpose": "",
+  "purpose_reasoning": "",
+  "responsibility": "",
+  "responsibility_reasoning": "",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/.plan/project-architecture/quarkus-bom/enriched.json
+++ b/.plan/project-architecture/quarkus-bom/enriched.json
@@ -1,0 +1,79 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {},
+  "purpose": "",
+  "purpose_reasoning": "",
+  "responsibility": "",
+  "responsibility_reasoning": "",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,3 +121,12 @@ All cuioss repositories have branch protection on `main`. Direct pushes to `main
    - Every comment MUST get a reply (reason for fix or reason for not fixing) and MUST be resolved
 7. Do **NOT** enable auto-merge unless explicitly instructed. Wait for user approval.
 8. Return to main: `git checkout main && git pull`
+
+## Temporary Files
+
+Use `.plan/temp/` for ALL temporary and generated files (covered by `Write(.plan/**)` permission — avoids permission prompts).
+
+## Tool Usage
+
+- Use proper tools (Edit, Read, Write) instead of shell commands (echo, cat)
+- Never use Bash for file operations (find, grep, cat, ls) — use Glob, Read, Grep tools instead


### PR DESCRIPTION
## Summary

Initializes plan-marshall project configuration for this repository (via `/marshall-steward` first-run wizard).

## Changes

- **`.gitignore`** — added the managed `.plan/` block (tracks `marshal.json` + `project-architecture/`).
- **`marshal.json`** — skill domains `documentation, java, general-dev`; providers `git, github` (Sonar declined); `standard` finalize preset; verification steps `quality-gate, module-tests, coverage`; merge queue enabled (`use_merge_queue=true`); `automatic-review` lane off (no PR-review bots).
- **`.plan/project-architecture/`** — discovered module architecture (8 POM/BOM modules + doc module).
- **`CLAUDE.md`** — appended "Temporary Files" and "Tool Usage" guidance (deterministic docs fixer).

## Notes

- No Java source in this repo (POM/BOM aggregator); `module-tests`/`coverage` no-op gracefully.
- Labelled `skip-bot-review` — configuration-only change, no code review needed.
