### PR TITLE
fix: exclude defective JavaUtilAPIs/UseMapOf recipe from pre-commit profile

### DIFF
--- a/cui-java-bom/cui-java-parent/pom.xml
+++ b/cui-java-bom/cui-java-parent/pom.xml
@@ -286,7 +286,13 @@
 
                                 <!-- Not included in UpgradeToJava21 -->
                                 <recipe>org.openrewrite.java.migrate.RemoveSecurityManager</recipe>
-                                <recipe>org.openrewrite.java.migrate.util.JavaUtilAPIs</recipe>
+                                <!-- JavaUtilAPIs intentionally excluded: its transitive UseMapOf recipe produces -->
+                                <!-- broken, non-compiling output - rewrites LinkedHashMap put-chains into -->
+                                <!-- new HashMap<>(Map.of(...)) without importing HashMap, feeds nulls into -->
+                                <!-- null-intolerant Map.of(), and discards insertion-ordering guarantees. -->
+                                <!-- OpenRewrite offers no per-sub-recipe exclusion, so the whole composite is dropped. -->
+                                <!-- See TokenSheriff PR #577 for the downstream failure modes this prevents. -->
+                                <!-- <recipe>org.openrewrite.java.migrate.util.JavaUtilAPIs</recipe> -->
 
                                 <!-- Code organization -->
                                 <recipe>org.openrewrite.java.OrderImports</recipe>


### PR DESCRIPTION
## Problem

The `-Ppre-commit` profile in `cui-java-parent/pom.xml` declares
`org.openrewrite.java.migrate.util.JavaUtilAPIs` in its `activeRecipes`.
That composite transitively includes `UseMapOf`, which produces broken,
non-compiling output:

- Rewrites `new LinkedHashMap<>()` + put-chains into `new HashMap<>(Map.of(...))`
  **without adding the `java.util.HashMap` import** → `symbol not found: HashMap`
  compile failures.
- Feeds `null` values into null-intolerant `Map.of(...)` → `NullPointerException`
  at runtime and in tests.
- Silently discards `LinkedHashMap` insertion-ordering guarantees.

## Fix

OpenRewrite offers no mechanism to exclude a single sub-recipe from a composite,
so the whole `JavaUtilAPIs` composite is dropped from the shared pre-commit
`activeRecipes` list (left as a commented-out line with rationale for future
readers). `RemoveSecurityManager` and the CUI logging recipes are unchanged.

## Verification

- `help:effective-pom -Ppre-commit` on `cui-java-parent`: the resolved
  `activeRecipes` set no longer contains `JavaUtilAPIs`/`UseMapOf`
  (`RemoveSecurityManager` and `InvalidExceptionUsageRecipe` still present).
- `./mvnw -Ppre-commit verify`: builds cleanly, zero working-tree churn.

## Downstream impact

Fixing this at the parent removes the need for the per-repo
`combine.self=override` `activeRecipes` workaround applied downstream in
TokenSheriff PR #577.

## Note

`InvalidExceptionUsageRecipe` (also flagged for injecting `cui-rewrite:disable`
TODO markers that churn source lines / break SonarCloud new-code coverage) is
**intentionally left in place** — it is a CUI-owned recipe whose defect is
better fixed at source in `cui-open-rewrite` than worked around here. Out of
scope for this PR.