### PR TITLE
chore: trigger Maven build on merge_group to unblock the merge queue

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -3,6 +3,9 @@
 name: Maven Build
 
 on:
+  # Required so the 'build / conclusion' status check runs on the merge-queue
+  # branch; without it, queued PRs stay CLEAN but never merge (queue times out).
+  merge_group:
   push:
     branches: [main, "feature/*", "fix/*", "chore/*", "release/*", "dependabot/**"]
   pull_request:


### PR DESCRIPTION
## Problem

The `main` ruleset enables a **merge queue** whose required status check is
`build / conclusion` (strict policy). For the queue to merge an entry, that
check must run on the `merge_group` event on the `gh-readonly-queue/main/*`
branch.

`.github/workflows/maven.yml` triggered only on `push` / `pull_request` /
`workflow_dispatch` — **no `merge_group` trigger**. As a result the build never
ran on the queue branch, `build / conclusion` was never reported there, and
queued PRs sat CLEAN but never merged (they were dropped after the queue's
`check_response_timeout_minutes: 60`). This blocked every PR to the repo.

## Fix

Add the `merge_group:` trigger to `maven.yml` so the build runs on the queue
branch and the required check reports.

## Note

This PR is admin-merged to break the chicken-and-egg (the queue can't merge the
fix that unblocks the queue). After it lands, subsequent PRs merge normally
through the queue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build validation to run for pull requests entering the merge queue.
  * Existing build and status checks remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->