### PR TITLE
chore(release): prepare release 1.5.2

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -2,7 +2,7 @@ name: cui parent pom
 description: Parent pom for all CUI-OSS projects
 
 release:
-  current-version: 1.5.1
+  current-version: 1.5.2
   next-version: 1.5-SNAPSHOT
   create-github-release: true
 

--- a/README.adoc
+++ b/README.adoc
@@ -39,7 +39,7 @@ toc::[]
 <parent>
    <groupId>de.cuioss</groupId>
    <artifactId>cui-parent-pom</artifactId>
-   <version>1.5.1</version> <!-- use the latest release -->
+   <version>1.5.2</version> <!-- use the latest release -->
 </parent>
 ----
 
@@ -70,7 +70,7 @@ toc::[]
     <parent>
         <groupId>de.cuioss</groupId>
         <artifactId>cui-java-parent</artifactId>
-        <version>1.5.1</version>
+        <version>1.5.2</version>
     </parent>
     <artifactId>cui-java-sample</artifactId>
     <name>cui java sample</name>


### PR DESCRIPTION
Bump current-version to 1.5.2 (next-version stays 1.5-SNAPSHOT) and the README parent sample. Triggers the automated Release workflow on merge.