### PR TITLE
chore(release): set version.cui.parent to 1.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     </repositories>
 
     <properties>
-        <version.cui.parent>1.5.1</version.cui.parent>
+        <version.cui.parent>1.5.2</version.cui.parent>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.assembly.plugin.version>3.8.0</maven.assembly.plugin.version>


### PR DESCRIPTION
Lands the `version.cui.parent` → 1.5.2 property bump that the release workflow's `preparationGoals` would normally push to main. The workflow's direct push was rejected by the new merge-queue rule (now fixed by exempting the release app). 1.5.2 is already published to Maven Central; this completes the git side of the release.