### PR TITLE
build(pre-commit): exclude Docker Compose files from OpenRewrite parsing

### DIFF
--- a/cui-java-bom/cui-java-parent/pom.xml
+++ b/cui-java-bom/cui-java-parent/pom.xml
@@ -312,6 +312,9 @@
                             <!-- Exclude generated files from being processed -->
                             <exclusions>
                                 <exclusion>target/**</exclusion>
+                                <exclusion>**/docker-compose.yml</exclusion>
+                                <exclusion>**/compose.yml</exclusion>
+                                <exclusion>**/compose.yaml</exclusion>
                             </exclusions>
                             <runPerSubmodule>true</runPerSubmodule>
                         </configuration>


### PR DESCRIPTION
## Summary

Adds Docker Compose filename patterns to the `rewrite-maven-plugin` `<exclusions>`
in the shared `pre-commit` profile of `cui-java-parent`, so the OpenRewrite YAML
parser stops emitting a noisy (non-failing) `There were problems parsing
<path>/docker-compose.yml` WARNING on every `verify -Ppre-commit` run.

The parser cannot handle Docker Compose files whose `healthcheck` uses shell
redirection (valid Compose syntax). No active recipe in the profile targets
Compose files, so excluding them loses nothing.

## Change

In `cui-java-bom/cui-java-parent/pom.xml`, the `pre-commit` profile's
`rewrite-maven-plugin` `<exclusions>` block gains three patterns alongside the
existing `target/**`:

```xml
<exclusion>**/docker-compose.yml</exclusion>
<exclusion>**/compose.yml</exclusion>
<exclusion>**/compose.yaml</exclusion>
```

`**/docker-compose.yml` is the classic filename that triggers the warning;
`**/compose.yml` / `**/compose.yaml` are the newer canonical Compose filenames,
excluded proactively.

## Downstream context

TokenSheriff carried this exclusion as a local per-repo pom override (removed in
TokenSheriff PR #584 when adopting cui-java-parent 1.5.2). Moving it into the
parent silences the warning for every consumer and removes the need for per-repo
overrides. A new `cui-java-parent` release will follow so consumers can adopt it.
