### PR TITLE
chore: add API-Sheriff to consumers

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -43,6 +43,7 @@ consumers:
   - cui-test-mockwebserver-junit5
   - cui-test-value-objects
   - TokenSheriff
+  - API-Sheriff
 
 dependency-propagation:
   group-id: de.cuioss


### PR DESCRIPTION
Adds `API-Sheriff` to the `consumers` list in `.github/project.yml`.